### PR TITLE
More informative (and correct) extension description

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -11,6 +11,7 @@
   <packaging>pom</packaging>
   <artifactId>quarkus-microprofile-platform-parent</artifactId>
   <name>Quarkus - MicroProfile Platform</name>
+  <description>The Quarkus MicroProfile Extension bundles all MicroProfile specifications and SmallRye implementations into a single extension dependency for easy consumption.</description>
 
   <modules>
     <module>runtime</module>

--- a/platform/runtime/pom.xml
+++ b/platform/runtime/pom.xml
@@ -9,7 +9,6 @@
 
     <artifactId>quarkus-microprofile</artifactId>
     <name>Quarkus - MicroProfile Platform - Runtime</name>
-    <description>Quarkus MicroProfile 4.1 Compatible Implementation</description>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
I noticed when looking at https://quarkus.io/extensions/io.quarkiverse.microprofile/quarkus-microprofile/ that the description is pretty terse, and it references Microprofile 4.1 instead of 6.1. 

The description that gets put into the extension metadata comes from the pom. There's a description in the runtime pom but the parent pom seems more logical, so I've moved it there. I couldn't find a nice property to use for the microprofile version, so I've just removed it to save a maintenance burden. 